### PR TITLE
Fix/encoding

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,9 @@
+2018-10-26  Václav Hausenblas  <vencahaus@seznam.cz>
+
+	* src/parse.cpp: Encoding of strings returned by the parser declared as UTF-8
+	* R/parseToml.R: non-file text inputs are converted to UTF-8 if necessary
+	* man/parseTOML.Rd: Documentation
+
 2018-10-25  Dirk Eddelbuettel  <edd@debian.org>
 
 	* src/parse.cpp (getValue): Support local time

--- a/R/parseToml.R
+++ b/R/parseToml.R
@@ -21,7 +21,7 @@ parseTOML <- function(input, verbose=FALSE, fromFile=TRUE, includize=FALSE, esca
     if (fromFile) {
         toml <- tomlparseImpl(path.expand(input), verbose, fromFile, includize, escape)
     } else {
-        toml <- tomlparseImpl(input, verbose, fromFile, includize, escape)
+        toml <- tomlparseImpl(enc2utf8(input), verbose, fromFile, includize, escape)
     }
     class(toml) <- c("toml", "list")
     attr(toml, "file") <- input

--- a/man/parseTOML.Rd
+++ b/man/parseTOML.Rd
@@ -44,6 +44,8 @@
   Geigle. This requires a recent-enough C++11 compiler which excludes
   one deployed by Rtools on Windows at the time the package was
   initially put together.
+  
+  Following TOML specification this package assumes that any file input is a UTF-8 encoded text file. Any non-file input (when \code{fromFile = FALSE}) is converted to UTF-8 if necessary (using R's \code{enc2utf()}. Note that the conversion to UTF-8 may fail for input with "unknown" declared encoding if the true encoding does not match system's locale. 
 }
 \value{
   A \code{toml} object is returned, which is really just a list object

--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -98,7 +98,8 @@ SEXP getValue(const std::shared_ptr<cpptoml::base>& base, bool escape=true) {
         if (escape) {
             s = escapeString(s);
         }
-        return Rcpp::wrap(s);
+        Rcpp::String se(s, CE_UTF8);
+        return Rcpp::wrap(se);
     } else if (auto v = base->as<int64_t>()) {
         std::int64_t s(v->get());
         int t = static_cast<int>(s); // we need int for wrap to work


### PR DESCRIPTION
Issue #28. 

It looks good and surprisingly easy.

```
> test_input <- enc2utf8("value='Žluťoučký kůň'")
> Encoding(test_input)
[1] "UTF-8"
> test_output <- RcppTOML::parseTOML(test_input, fromFile = FALSE)$value
> cat(test_output)
Žluťoučký kůň
> Encoding(test_output)
[1] "UTF-8"
```

[test.txt](https://github.com/eddelbuettel/rcpptoml/files/2519698/test.txt)

```
> test_file <- RcppTOML::parseTOML("test.txt")
> test_file$value
[1] "Žluťoučký kůň"
> Encoding(test_file$value)
[1] "UTF-8"
```

I only have two doubts.

1) Maybe this is unneccessarily expensive solution? `Rf_mkCharCE`?
```
Rcpp::String se(s, CE_UTF8);
return Rcpp::wrap(se);
```

2) Maybe doing `enc2utf8(input)` is too strict. Some R functions for string manipulations have `encoding` argument allowing for various other encodings and use `iconv(x, from=encoding, to='UTF-8')` to convert it. But I ditched this idea since it would not apply to cases where `fromFile=TRUE` and that would be very confusing.

This pull request is just a kick-off. I will add some documentation before merging after we agree on the right solution.