### PR TITLE
fix #28 again (declare UTF-8 in arrays of strings)

### DIFF
--- a/src/parse.cpp
+++ b/src/parse.cpp
@@ -211,7 +211,8 @@ SEXP collapsedList(Rcpp::List ll) {
             Rcpp::CharacterVector v(n);
             for (int i=0; i<n; i++) {
                 std::string s = Rcpp::as<std::string>(ll[i]);
-                v[i] = s;
+                Rcpp::String se(s, CE_UTF8);
+                v[i] = se;
             }
             return v;
             break;              // not reached ...


### PR DESCRIPTION
This should be the last piece to fix #28. The fixes in #30 did not address strings in arrays.