### PR TITLE
fix test of unicode support on Windows

### DIFF
--- a/inst/tinytest/test_examples.R
+++ b/inst/tinytest/test_examples.R
@@ -31,7 +31,7 @@ expect_equal(toml$servers$alpha$dc, "eqdc10")
 expect_true(setequal(names(toml$servers$beta), c("ip", "dc", "country")))
 expect_equal(toml$servers$beta$ip, "10.0.0.2")
 expect_equal(toml$servers$beta$dc, "eqdc10")
-if (!isWindows) expect_equal(toml$servers$beta$country, "中国")
+expect_equal(toml$servers$beta$country, "\u4e2d\u56fd")
 
 expect_true(setequal(names(toml$clients), c("data", "hosts")))
 expect_true(setequal(toml$clients$data, list(c("gamma", "delta"), c(1L, 2L))))


### PR DESCRIPTION
This should make the test of unicode support pass even on systems without UTF-8. Passes all tests on my Windows 7 system (set to Czech locale). 