### PR TITLE
Update the version of Rcpp required

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2023-05-26 Walter Somerville <waltersom@gmail.com>
+
+	* DESCRIPTION (Imports): Updated minimum version of Rcpp
+
 2023-01-29  Dirk Eddelbuettel  <edd@debian.org>
 
 	* DESCRIPTION (Version, Date): Release 0.2.2

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2023-05-26  Walter Somerville <waltersom@gmail.com>
+2023-05-26  Walter Somerville  <waltersom@gmail.com>
 
 	* DESCRIPTION (Imports): Updated minimum version of Rcpp
 

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2023-05-26 Walter Somerville <waltersom@gmail.com>
+2023-05-26  Walter Somerville <waltersom@gmail.com>
 
 	* DESCRIPTION (Imports): Updated minimum version of Rcpp
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,7 @@ Description: The configuration format defined by 'TOML' (which expands to
 SystemRequirements: A C++17 compiler
 BugReports: https://github.com/eddelbuettel/rcpptoml/issues
 URL: http://dirk.eddelbuettel.com/code/rcpp.toml.html
-Imports: Rcpp (>= 0.11.5)
+Imports: Rcpp (>= 1.0.8)
 Depends: R (>= 3.3.0)
 LinkingTo: Rcpp
 Suggests: tinytest


### PR DESCRIPTION
Because of the use of Rcpp/Lightest, Rcpp>=1.0.8 is now needed (instead of 0.11.5).

Closes #53